### PR TITLE
alt_email can be nil, use blank? instead of empty?

### DIFF
--- a/app/mailers/registration_notifier_mailer.rb
+++ b/app/mailers/registration_notifier_mailer.rb
@@ -5,7 +5,7 @@ class RegistrationNotifierMailer < ApplicationMailer
     @guest_reg = guest_reg
     header = {}
     header.store(:to, guest_reg.email)
-    header.store(:cc, guest_reg.alt_email) unless guest_reg.alt_email.empty?
+    header.store(:cc, guest_reg.alt_email) unless guest_reg.alt_email.blank?
     header.store(:subject, IwaoConfig.fetch(:email_subject_registration_receipt))
     mail(header)
   end
@@ -23,7 +23,7 @@ class RegistrationNotifierMailer < ApplicationMailer
     @guest_reg = guest_reg
     header = {}
     header.store(:to, guest_reg.email)
-    header.store(:cc, guest_reg.alt_email) unless guest_reg.alt_email.empty?
+    header.store(:cc, guest_reg.alt_email) unless guest_reg.alt_email.blank?
     header.store(:subject, IwaoConfig.fetch(:email_subject_registration_approved))
     mail(header)
   end


### PR DESCRIPTION
> [12] pry(main)> nil.blank?
> => true
> [13] pry(main)> nil.empty?
> NoMethodError: undefined method `empty?' for nil:NilClass
> from (pry):13:in `__pry__'